### PR TITLE
Disable no-var-requires, member-ordering

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -32,6 +32,8 @@
     },
     "no-reference-import": false,
     "no-submodule-imports": false,
-    "max-line-length": 80
+    "max-line-length": 80,
+    "no-var-requires": false,
+    "member-ordering": false
   }
 }


### PR DESCRIPTION
* no-var-requires prevents from importing `react-google-charts`
* member-ordering enforces funky properties order when
  describing the properties of charts