### PR TITLE
Add d.ts for react-google-charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/classnames": "^2.2.3",
     "@types/enzyme": "^2.8.11",
+    "@types/google.visualization": "^0.0.40",
     "@types/jest": "^21.1.5",
     "@types/jsonp": "^0.2.0",
     "@types/react-dom": "^16.0.1",

--- a/src/pages/stats/pages/wakatime/common.tsx
+++ b/src/pages/stats/pages/wakatime/common.tsx
@@ -17,11 +17,6 @@ export interface IViewProps {
   stage: DataLoadingStage;
 }
 
-export interface IChartColumn {
-  label: string;
-  type: 'string' | 'number';
-}
-
 export abstract class WakaTimeContainer extends React.Component<any, IContainerState> {
   protected dataUrl: string;
 

--- a/src/pages/stats/pages/wakatime/editor.tsx
+++ b/src/pages/stats/pages/wakatime/editor.tsx
@@ -1,21 +1,19 @@
 import * as React from 'react';
-const Chart = require('react-google-charts').Chart;
+import { Chart, ChartColumn, PieChartOptions } from 'react-google-charts';
 
 import Spinner from '../../../../common/spinner';
-import { DataLoadingStage, IChartColumn, IViewProps, WakaTimeContainer } from './common';
+import { DataLoadingStage, IViewProps, WakaTimeContainer } from './common';
 
 class WakaTimeEditorView extends React.Component<IViewProps, any> {
-  private chartOptions: any;
-  private chartColumns: IChartColumn[];
+  private chartOptions: PieChartOptions;
+  private chartColumns: ChartColumn[];
 
   constructor(props: IViewProps, state: any) {
     super(props, state);
 
     this.chartOptions = {
-      hAxis: { title: 'Editor' },
       legend: 'none',
-      title: 'Editor/IDE usage',
-      vAxis: { title: '%' }
+      title: 'Editor/IDE usage'
     };
     this.chartColumns = [
       {

--- a/src/pages/stats/pages/wakatime/lang.tsx
+++ b/src/pages/stats/pages/wakatime/lang.tsx
@@ -1,21 +1,19 @@
 import * as React from 'react';
-const Chart = require('react-google-charts').Chart;
+import { Chart, ChartColumn, PieChartOptions } from 'react-google-charts';
 
 import Spinner from '../../../../common/spinner';
-import { DataLoadingStage, IChartColumn, IViewProps, WakaTimeContainer } from './common';
+import { DataLoadingStage, IViewProps, WakaTimeContainer } from './common';
 
 class WakaTimeLangStatsView extends React.Component<IViewProps, any> {
-  private chartOptions: any;
-  private chartColumns: IChartColumn[];
+  private chartOptions: PieChartOptions;
+  private chartColumns: ChartColumn[];
 
   constructor(props: IViewProps, state: any) {
     super(props, state);
 
     this.chartOptions = {
-      hAxis: { title: 'Language' },
       legend: 'none',
-      title: 'Language usage',
-      vAxis: { title: '%' }
+      title: 'Language usage'
     };
     this.chartColumns = [
       {

--- a/src/pages/stats/pages/wakatime/os.tsx
+++ b/src/pages/stats/pages/wakatime/os.tsx
@@ -1,20 +1,18 @@
 import * as React from 'react';
-const Chart = require('react-google-charts').Chart;
+import { Chart, ChartColumn, PieChartOptions } from 'react-google-charts';
 
 import Spinner from '../../../../common/spinner';
-import { DataLoadingStage, IChartColumn, IViewProps, WakaTimeContainer } from './common';
+import { DataLoadingStage, IViewProps, WakaTimeContainer } from './common';
 class WakaTimeOSStatsView extends React.Component<IViewProps, any> {
-  private chartOptions: any;
-  private chartColumns: IChartColumn[];
+  private chartOptions: PieChartOptions;
+  private chartColumns: ChartColumn[];
 
   constructor(props: IViewProps, state: any) {
     super(props, state);
 
     this.chartOptions = {
-      hAxis: { title: 'OS' },
       legend: 'none',
-      title: 'OS usage',
-      vAxis: { title: '%' }
+      title: 'OS usage'
     };
     this.chartColumns = [
       {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,54 @@
+/// <reference types="react"/>
+/// <reference types="google.visualization"/>
+
+declare module 'react-google-charts' {
+
+  export interface ChartEvent {
+    eventName: 'select';
+    callback: FunctionConstructor;
+  }
+
+  export type ChartColumn = google.visualization.DataTableColumnDescription;
+
+  // options for different types of charts
+  export type BarChartOptions = google.visualization.BarChartOptions;
+  export type PieChartOptions = google.visualization.PieChartOptions;
+  export type AreaChartOptions = google.visualization.AreaChartOptions;
+  export type AnnotationChartOptions = google.visualization.AnnotationChartOptions;
+  export type SteppedAreaChartOptions = google.visualization.SteppedAreaChartOptions;
+  export type BubbleChartOptions = google.visualization.BubbleChartOptions;
+  export type CandlestickChartOptions = google.visualization.CandlestickChartOptions;
+  export type ComboChartOptions = google.visualization.ComboChartOptions;
+  export type OrgChartOptions = google.visualization.OrgChartOptions;
+  export type GeoChartOptions = google.visualization.GeoChartOptions;
+  export type ScatterChartOptions = google.visualization.ScatterChartOptions;
+  export type ColumnChartOptions = google.visualization.ColumnChartOptions;
+  export type LineChartOptions = google.visualization.LineChartOptions;
+  export type HistogramChartOptions = google.visualization.HistogramOptions;
+  // options for different types of charts
+
+  type ChartType = 'PieChart' | 'BarChart' | 'Timeline' | 'ScatterChart' |
+    'LineChart' | 'AreaChart' | 'AnnotationChart' | 'SteppedChart' | 'BubbleChart';
+  type ChartOptionsType = BarChartOptions | PieChartOptions | AreaChartOptions | AnnotationChartOptions |
+    SteppedAreaChartOptions | BubbleChartOptions | CandlestickChartOptions | ComboChartOptions |
+    OrgChartOptions | GeoChartOptions | ScatterChartOptions | ColumnChartOptions | LineChartOptions | HistogramChartOptions;
+
+  export interface ChartProps {
+    chartType: ChartType;
+    graph_id: string;
+    width: string;
+    height: string;
+    rows?: any[][];
+    columns?: ChartColumn[];
+    data?: any[][];
+    options?: ChartOptionsType;
+    legend_toggle?: boolean;
+    allowEmptyRows?: boolean;
+    chartEvents?: ChartEvent[];
+    colors?: string[];
+  }
+  export class Chart extends React.Component<ChartProps> {
+
+  }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,11 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
-    "diagnostics": true
+    "diagnostics": true,
+    "typeRoots": [
+      "src/types/",
+      "node_modules/@types/"
+    ]
   },
   "exclude": [
     "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -34,6 +34,8 @@
     "no-submodule-imports": false,
     "max-line-length": 80,
     "no-var-requires": false,
-    "member-ordering": false
+    "member-ordering": false,
+    "interface-name": false,
+    "no-implicit-dependencies": [true, "dev"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
+"@types/google.visualization@^0.0.40":
+  version "0.0.40"
+  resolved "https://registry.yarnpkg.com/@types/google.visualization/-/google.visualization-0.0.40.tgz#c82648b13b17fb55837da80a514f2348973c4b94"
+
 "@types/history@*":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.0.tgz#093d67ed780d889c9543f6dca24ebee0b6b9fc45"


### PR DESCRIPTION
Decided to roll with builtin type definition for react-google-charts.
As it uses the `google-charts` underneath, the new types reuses some
of the definitions from `@types/google.visualization`