### PR TITLE
Adding resume to the korni

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "resume"]
+	path = resume
+	url = git@github.com:kornicameister/CV.git

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.3",
   "private": true,
   "lint-staged": {
-    "src/**/*.{js,jsx,json,css,ts,tsx}": [
+    "src/**/*.{js,jsx,css,ts,tsx}": [
       "yarn lint",
       "git add"
     ]

--- a/src/static/resume.json
+++ b/src/static/resume.json
@@ -1,0 +1,357 @@
+{
+  "basics": {
+    "name": "Tomasz Trębski",
+    "label": "Programmer",
+    "picture": "",
+    "email": "tomasz.trebski@gmail.com",
+    "phone": "+48 789231312",
+    "website": "https://kornicameister.github.io/",
+    "summary": "Man whose work is his pride I am always trying to push myself and others to try and see all variables of the equation as for me there's no ideal solution. There is no such thing as closed door that I wouldn't try to open, the only problem is the time I need to unlock it. I am a person who believes in all the things he can touch, smell and see. Raised to think for himself and to always fight for his beliefs. Never to back down, because nobody will give me what I desire. There are few things that I consider most important in my life, yet my wife and daughter happiness is one of those things. Everything I ever accomplished and will accomplish is dedicated to them.",
+    "location": {
+      "address": "Niciarniana 13/4",
+      "postalCode": "92-238",
+      "city": "Łódź",
+      "countryCode": "PL",
+      "region": "Łódzkie"
+    },
+    "profiles": [
+      {
+        "network": "Github",
+        "username": "kornicameister",
+        "url": "https://github.com/kornicameister"
+      },
+      {
+        "network": "Gitlab",
+        "username": "kornicameister",
+        "url": "https://gitlab.com/kornicameister"
+      },
+      {
+        "network": "LinkedIn",
+        "username": "tomasz.trebski",
+        "url": "https://www.linkedin.com/in/tomasz.trebski"
+      },
+      {
+        "network": "StackOverflow",
+        "username": "kornicameister",
+        "url": "https://stackoverflow.com/users/1396508"
+      },
+      {
+        "network": "LastFM",
+        "username": "kornicameister",
+        "url": "https://www.last.fm/pl/user/kornicameister"
+      }
+    ]
+  },
+  "work": [
+    {
+      "company": "Fujitsu Technology Solutions Sp. z o.o.",
+      "position": "Senior Development Engineer",
+      "website": "http://www.fujitsu.com/pl/about/local/lodz/",
+      "startDate": "01.11.2017",
+      "endDate": "",
+      "summary": "NGI: Cloud Orchestration",
+      "highlights": [
+        "Responsible for both client and server side"
+      ]
+    },
+    {
+      "company": "Fujitsu Technology Solutions Sp. z o.o.",
+      "position": "(Senior) Development Engineer",
+      "website": "http://www.fujitsu.com/pl/about/local/lodz/",
+      "startDate": "01.03.2015",
+      "endDate": "31.10.2017",
+      "summary": "Cloud Monitoring Management: CMM",
+      "highlights": [
+        "Initial author of the open source openstack/monasca-log-api project in Python. Also a contributor to the Java implementation of the same project. Projects aims to be a REST-ful API receiving logs from agents deployed on target machines to collect them",
+        "Initial author of the open source openstack/monasca-log-api project, Python implementation, also a contributor to the Java implementation of the same project. Projects aims to be a REST-ful API receiving logs from agents deployed on target machines to collect them - plugin bringing multitenancy of OpenStack to Kibana",
+        "Initial author of the open source keystone-v3-client project - Keystone binding for Node.JS",
+        "One of the authors of PostgreSQL support for monasca",
+        "Core-Reviewer at OpenStack’s Gerrit for monasca-* projects, designed to monitor cloud environment",
+        "Major contributor for monasca at Openstack",
+        "Contributor to monasca-docker (monasca in containers)",
+        "Author of several migrations in monasca projects [i.e. oslo.config, cliff]"
+      ]
+    },
+    {
+      "company": "Fujitsu Technology Solutions Sp. z o.o.",
+      "position": "Development Engineer",
+      "website": "http://www.fujitsu.com/pl/about/local/lodz/",
+      "startDate": "01.01.2015",
+      "endDate": "28.02.2015",
+      "summary": "OpenService Catalog Manager",
+      "highlights": [
+        "Responsible for porting an application to newer Glassfish (3.x), both in server side and client side"
+      ]
+    },
+    {
+      "company": "Transition Technologies Solutions S.A.",
+      "position": "Java & JavaScript Developer",
+      "website": "https://tt.com.pl",
+      "startDate": "01.02.2013",
+      "endDate": "31.12.2014",
+      "summary": "",
+      "highlights": [
+        "Primarily working with Windchill customization/extensions on 2 different projects. One of them was developed forAirbus Helicopterscom-pany, focused on adding new functionalities according to client specification. Actively participated ind development of migration tool to allowAirbus Helicoptersupload data from their legacy system through JMS queue (Tibco). Customizing Windchill forScaniawas short experience.Assignment were circling around development of new features, mostly frontend of Windchill.",
+        "Worked as Java/JavaScript developer at project meant to support field technicians. Product was build in client-server architecture, havingWindchill in the backend and web application, based on Angular as a frontend. Being member of this team meant working both with JavaScriptand Java code.",
+        "Preparing JavaScript trainings (internal, external)",
+        "Assisting on recruitment of new employees",
+        "Internship leader"
+      ]
+    },
+    {
+      "company": "Transition Technologies Solutions S.A",
+      "position": "Intern",
+      "website": "https://tt.com.pl",
+      "startDate": "01.06.2012",
+      "endDate": "31.09.2012",
+      "summary": "Creating web based application [prototype written in ExtJS] for lifecycle management in Windchill system [PLM]",
+      "highlights": []
+    }
+  ],
+  "volunteer": [],
+  "education": [
+    {
+      "institution": "I Liceum Ogólnokształcące Józefa Chełmońskiego",
+      "area": "Łowicz",
+      "studyType": "HighSchool",
+      "startDate": "2006",
+      "endDate": "2009",
+      "gpa": "Mathematic and Computer Science",
+      "courses": []
+    },
+    {
+      "institution": "Technical University In Łódź",
+      "area": "Lódź",
+      "studyType": "Bachelor in Logistic",
+      "startDate": "2009",
+      "endDate": "2013",
+      "gpa": "WMS(Warehouse Management System) implementation with computer tools",
+      "courses": []
+    },
+    {
+      "institution": "Technical University In Łódź",
+      "area": "Lódź",
+      "studyType": "Bachelor in Computer Science",
+      "startDate": "2010",
+      "endDate": "2014",
+      "gpa": "Tool supporting car service station management using Spring application framework",
+      "courses": []
+    },
+    {
+      "institution": "Technical University In Łódź",
+      "area": "Lódź",
+      "studyType": "Master in Computer Science",
+      "startDate": "2014",
+      "endDate": "2016",
+      "gpa": "Collecting, analysis and inferring - meaning of logs in cloud environment",
+      "courses": []
+    }
+  ],
+  "awards": [
+    {
+      "title": "Pegazy innowacji",
+      "date": "2013",
+      "awarder": "Transition Technologies S.A.",
+      "summary": "Awarded for overall contribution to the project and internships"
+    },
+    {
+      "title": "Bronze Medal",
+      "date": "2015",
+      "awarder": "Fujitsu Technology Solutions Sp. z.o.o",
+      "summary": "Awarded for the creation of monasca-log-api"
+    },
+    {
+      "title": "Silver Medal",
+      "date": "2016",
+      "awarder": "Fujitsu Technology Solutions Sp. z.o.o",
+      "summary": "Awarded for extraordinary performance and results in the project CMM"
+    }
+  ],
+  "publications": [
+    {
+      "name": "Monitoring of OpenStack Clouds",
+      "publisher": "OpenStack Day",
+      "releaseDate": "2017-03-22",
+      "website": "",
+      "summary": "Overview of cloud monitoring with monasca"
+    },
+    {
+      "name": "Monasca Bootcamp",
+      "publisher": "Openstack Summmit 2016 - Barcelona",
+      "releaseDate": "2016-10-26",
+      "website": "",
+      "summary": "Live presentation of monasca features with practical examples"
+    }
+  ],
+  "skills": [
+    {
+      "name": "Overall",
+      "level": "",
+      "keywords": [
+        "#team_work",
+        "#communicative",
+        "#love_challanges",
+        "#love_learning"
+      ]
+    },
+    {
+      "name": "Programming",
+      "level": "",
+      "keywords": [
+        "Java",
+        "ES5",
+        "ES6",
+        "HTML5",
+        "CSS",
+        "Python2",
+        "Python 3",
+        "SQL",
+        "YAML",
+        "JSON",
+        "LaTex",
+        "TypeScript",
+        "Bash"
+      ]
+    },
+    {
+      "name": "Python",
+      "level": "",
+      "keywords": [
+        "oslo.*",
+        "Alembic",
+        "six",
+        "gunicorn",
+        "Falcon",
+        "tox",
+        "cliff",
+        "WSGI"
+      ]
+    },
+    {
+      "name": "Databases",
+      "level": "",
+      "keywords": [
+        "MySQL",
+        "PostgreSQL",
+        "ElasticSearch",
+        "InfluxDB"
+      ]
+    },
+    {
+      "name": "CVS",
+      "level": "",
+      "keywords": [
+        "Git",
+        "SVN",
+        "OSC"
+      ]
+    },
+    {
+      "name": "IDEs",
+      "level": "",
+      "keywords": [
+        "Eclipse",
+        "IntelliJ IDEA",
+        "WebStorm",
+        "PyCharm",
+        "Atom",
+        "VIM",
+        "VSCode"
+      ]
+    },
+    {
+      "name": "QA",
+      "level": "",
+      "keywords": [
+        "Travis",
+        "Gerrit",
+        "Gitlab CI",
+        "Openstack CI [Zuul]",
+        "Github Reviews",
+        "Gitlab Reviews"
+      ]
+    },
+    {
+      "name": "Java",
+      "level": "",
+      "keywords": [
+        "Spring (MVC, Data, Boot, Rest), ",
+        "Tetra",
+        "wro4j",
+        "jUnit",
+        "DynamicJasper",
+        "Wro4j",
+        "Ehcache",
+        "c3p0",
+        "Joda",
+        "Apache Tiles",
+        "Jackson",
+        "Guava",
+        "Hibernate",
+        "QueryDSL"
+      ]
+    },
+    {
+      "name": "JS",
+      "level": "",
+      "keywords": [
+        "NodeJS",
+        "React",
+        "ExtJS",
+        "Angular (1.*, familiar with 2.*)",
+        "Angular Material",
+        "Dojo",
+        "jQuery",
+        "Jasmine",
+        "Karma",
+        "NVM",
+        "Yarn"
+      ]
+    },
+    {
+      "name": "Docker",
+      "level": "",
+      "keywords": [
+        "building",
+        "publishing",
+        "export/import",
+        "compose",
+        "swarm"
+      ]
+    },
+    {
+      "name": "Deployment",
+      "level": "",
+      "keywords": [
+        "Ansible",
+        "Crowbar"
+      ]
+    }
+  ],
+  "languages": [
+    {
+      "language": "Polish",
+      "fluency": "Native speaker"
+    },
+    {
+      "language": "English",
+      "fluency": "Fluent in writing and speaking"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Tanks",
+      "keywords": [
+        "Historical battles, History of tanks"
+      ]
+    },
+    {
+      "name": "World of Tanks",
+      "keywords": [
+        "MMO",
+        "Arcade"
+      ]
+    }
+  ],
+  "references": []
+}


### PR DESCRIPTION
Main idea behind korni was to render my personal CV.
Therefore the commits adds the kornicameiter/CV as the submodule,
linking the resume.json into src/static folder.

* Had to disable linting over json